### PR TITLE
Prevent fatal error if $data is null

### DIFF
--- a/src/Modules/Module.php
+++ b/src/Modules/Module.php
@@ -34,7 +34,7 @@ abstract class Module implements \Webleit\ZohoCrmApi\Contracts\Module
             throw new InvalidResourceKey(json_encode($list));
         }
 
-        $collection = new RecordCollection($data);
+        $collection = new RecordCollection($data ?? []);
         $collection = $collection->mapWithKeys(function ($item) {
             $item = $this->make($item);
 


### PR DESCRIPTION
Don't error out of there are no records (This happens when using header changes to show only records from the last x timeframe, if nothing has changed zoho sends a 304 (see other PR for sending header)