### PR TITLE
Update zohoclient dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "psr/cache": "^1.0",
         "doctrine/inflector": "^2",
         "bentools/guzzle-throttle-middleware": "^0.4.1",
-        "weble/zohoclient": "^3.0.1",
+        "weble/zohoclient": "^3.0.1||^4.0",
         "spatie/enum": "^2.3",
         "cache/filesystem-adapter": "^1.0",
         "ext-json": "*"


### PR DESCRIPTION
Updated the weble/zohoclient dependency to ^4.0 because it creates incompatibility issues. Left ^3.0.1 in for backward compatibility if needed.