### PR TITLE
Return empty array if no records were found

### DIFF
--- a/src/Modules/Module.php
+++ b/src/Modules/Module.php
@@ -161,7 +161,8 @@ abstract class Module implements \Webleit\ZohoCrmApi\Contracts\Module
 
     public function getRelatedRecords(string $recordId, string $relationName): array
     {
-        return $this->client->get($this->getUrl() . '/' . $recordId . '/' . $relationName);
+        $items = $this->client->get($this->getUrl() . '/' . $recordId . '/' . $relationName);
+        return $items ? $items : [];
     }
 
     public function getUrlPath(): string

--- a/src/Modules/Module.php
+++ b/src/Modules/Module.php
@@ -161,8 +161,7 @@ abstract class Module implements \Webleit\ZohoCrmApi\Contracts\Module
 
     public function getRelatedRecords(string $recordId, string $relationName): array
     {
-        $items = $this->client->get($this->getUrl() . '/' . $recordId . '/' . $relationName);
-        return $items ? $items : [];
+        return $this->client->get($this->getUrl() . '/' . $recordId . '/' . $relationName) ?? [];
     }
 
     public function getUrlPath(): string


### PR DESCRIPTION
The method below has a return type `array`
````php
public function getRelatedRecords(string $recordId, string $relationName): array
    {
        return $this->client->get($this->getUrl() . '/' . $recordId . '/' . $relationName);
    }
````
However, in the situation where there are no records, Zoho API, unfortunately, does not send an empty array but either sends a string or boolean which will cause the method to produce the error below 
````
TypeError
Return value of Webleit\ZohoCrmApi\Modules\Module::getRelatedRecords() must be of the type array, string returned
````

In other to prevent such errors from breaking applications, I suggest the returned value is checked before returns as below. 
````php
public function getRelatedRecords(string $recordId, string $relationName): array
    {
        $items = $this->client->get($this->getUrl() . '/' . $recordId . '/' . $relationName);
        return $items ? $items : [];
    }
````
I wonder why the error indicates that the return was a string, meaning the above fix shouldn't have worked however, I think it is an empty or boolean value returned. That's why the fix above works. 

To reproduce the error that led to this pull request:

1. I had an already existing Contact (with email `email@domain.com`) and an Account (`Account Name`).
2. Created an Account (with the name `Second Account Name`) but no contact because the contact already existed. 

The problem here is, if you do not go through the extra step of adding the contact to the account, you may create deals, etc. without problems but when you try to get the contacts related to `Second Account Name` you will get an error because it is not attached. 

This will happen to any record without records from the relationship attached so it is not a specific use case. We could have easily solved it by removing the return type but for the sake of clean code and easy debugging, we can not allow just any data type to be returned, so we could rather check for the data returned and if empty return an empty array. 

I intentionally did not check for `is_array($items)` because that could prevent us from seeing some errors not related to the return type.