### PR TITLE
Update Module.php

### DIFF
--- a/src/Modules/Module.php
+++ b/src/Modules/Module.php
@@ -161,7 +161,9 @@ abstract class Module implements \Webleit\ZohoCrmApi\Contracts\Module
 
     public function getRelatedRecords(string $recordId, string $relationName): array
     {
-        return $this->client->get($this->getUrl() . '/' . $recordId . '/' . $relationName) ?? [];
+        $items = $this->client->get($this->getUrl() . '/' . $recordId . '/' . $relationName);
+
+        return empty($items) ? [] : $items;
     }
 
     public function getUrlPath(): string


### PR DESCRIPTION
ISSUE-93 : getRelatedRecords fails when response from API is empty string: Modified getRelatedRecords method to do a check the response of the API call on empty values (like empty strings / arrays, etc) before sending it as the result