### PR TITLE
chore: dependency updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,14 @@
     "require": {
         "php" : "^7.3 || ^8.0",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
-        "illuminate/collections": "^8.0 || ^9.0",
+        "illuminate/collections": "^8.0 || ^9.0 || ^10.0",
         "doctrine/inflector": "^2.0",
         "weble/zohoclient": "^4.2",
         "ext-json": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0 || ^9.0",
-        "nunomaduro/collision": "^5.0 || ^6.0",
+        "phpunit/phpunit": "^8.0 || ^9.0 || ^10.0",
+        "nunomaduro/collision": "^5.0 || ^6.0 || ^7.0",
         "cache/filesystem-adapter": "^1.0",
         "caseyamcl/guzzle_retry_middleware": "^2.6"
     },


### PR DESCRIPTION
Support Collections 10, PHPUnit 10, and collision 7 to allow use alongside Laravel 10